### PR TITLE
(Fix)Error fueling entity without fuel can qtarget

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -385,6 +385,7 @@ if Config.qtarget then
 		options = {
 			{
 				action = function (entity)
+					if not fuelingCan then return lib.notify({type = 'error', description = locale('petrolcan_missing')}) end
 					if fuelingCan.metadata.ammo <= Config.durabilityTick then return end
 					startFueling(entity)
 				end,

--- a/cs.json
+++ b/cs.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Nádrž vašeho vozidla je plná",
+	"petrolcan_cannot_afford": "Nemůžete si dovolit koupit kanystr",
+	"refuel_cannot_afford": "Nemůžete si dovolit natankovat vozidlo",
+	"vehicle_far": "Vozidlo je příliš daleko",
+	"pump_fuel_with_can": "Před tankováním pomocí pumpy odložte kanystr",
+	"fuel_help": "Stiskněte ~INPUT_C2939D45~ pro tankování",
+	"petrolcan_help": "Stiskněte ~INPUT_C2939D45~ pro koupení nebo doplnění kanystru",
+	"leave_vehicle": "Pro natankování musíte opustit vozidlo",
+	"start_fueling": "Začít tankovat",
+	"petrolcan_buy_or_refill": "Koupit/Naplnit kanystr",
+	"fuel_station_blip": "Čerpací stanice",
+	"not_enough_money": "Nedostatek peněz! Chybí $%s",
+	"fuel_success": "Natankováno na %s - $%s",
+	"petrolcan_refill": "Zaplaceno $%s za doplnění kanystru",
+	"petrolcan_buy": "Zaplaceno $%s za kanystr",
+	"petrolcan_cannot_carry": "Neunesete kanystr",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/de.json
+++ b/de.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Der Tank von diesem Fahrzeug ist voll",
+	"petrolcan_cannot_afford": "Du kannst dir keinen Treibstoffkanister leisten",
+	"refuel_cannot_afford": "Du kannst dir keine Tankfüllung leisten",
+	"vehicle_far": "Dein Fahrzeug ist zu weit entfernt",
+	"pump_fuel_with_can": "Mach deinen Treibstoffkanister weg, bevor du tankst",
+	"fuel_help": "Nutze ~INPUT_C2939D45~ um zu tanken",
+	"petrolcan_help": "Nutze ~INPUT_C2939D45~ um einen Treibstoffkanister zu kaufen / nachzufüllen",
+	"leave_vehicle": "Verlasse das Fahrzeug bevor du tankst",
+	"start_fueling": "Tanken starten",
+	"petrolcan_buy_or_refill": "Kauf, oder Fülle einen Treibstoffkanister nach",
+	"fuel_station_blip": "Tankstelle",
+	"not_enough_money": "Nicht genügend Geld! Es fehlen $%s",
+	"fuel_success": "Erfolgreich zu %s - $%s getankt",
+	"petrolcan_refill": "Du hast $%s für das Auffüllen deines Treibstoffkanisters bezahlt",
+	"petrolcan_buy": "Du hast $%s für einen Treibstoffkanister bezahlt",
+	"petrolcan_cannot_carry": "Du kannst diesen Treibstoffkanister nicht tragen",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/en.json
+++ b/en.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "The tank of this vehicle is full",
+	"petrolcan_cannot_afford": "You cannot afford a petrol can",
+	"refuel_cannot_afford": "You cannot afford to refuel your vehicle, cash only",
+	"vehicle_far": "Your vehicle is too far away",
+	"pump_fuel_with_can": "Put your can away before fueling with the pump",
+	"fuel_help": "Press ~INPUT_C2939D45~ to fuel",
+	"petrolcan_help": "Press ~INPUT_C2939D45~ to buy or refill a fuel can",
+	"leave_vehicle": "Leave the vehicle to be able to start fueling",
+	"start_fueling": "Start fueling",
+	"petrolcan_buy_or_refill": "Buy or refill a fuel can",
+	"fuel_station_blip": "Fuel station",
+	"not_enough_money": "Not enough money! Missing $%s cash",
+	"fuel_success": "Fueled to %s - $%s",
+	"petrolcan_refill": "Paid $%s for refilling your fuel can",
+	"petrolcan_buy": "Paid $%s for a fuel can",
+	"petrolcan_cannot_carry": "You cannot carry this fuel can",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/es.json
+++ b/es.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "El depósito está lleno",
+	"petrolcan_cannot_afford": "No puedes pagar el bidón de gasolina",
+	"refuel_cannot_afford": "No puedes pagar por respostar el vehículo",
+	"vehicle_far": "El vehículo está demasiado lejos",
+	"pump_fuel_with_can": "Guarda el bidón antes de respostar con el surtidor",
+	"fuel_help": "Presiona ~INPUT_C2939D45~ para repostar",
+	"petrolcan_help": "Presiona ~INPUT_C2939D45~ para comprar o rellenar el bidón de gasolina",
+	"leave_vehicle": "Sal del vehículo para repostar",
+	"start_fueling": "Empezar a repostar",
+	"petrolcan_buy_or_refill": "Comprar o rellenar bidón de gasolina",
+	"fuel_station_blip": "Gasolinera",
+	"not_enough_money": "No tienes suficiente dinero, faltan %s€",
+	"fuel_success": "Has repostado %s - %s€",
+	"petrolcan_refill": "Has pagado %s€ por rellenar tu bidón de gasolina",
+	"petrolcan_buy": "Has pagado %s€ por un bidón de gasolina",
+	"petrolcan_cannot_carry": "No puedes cargar este bidón de gasolina",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/et.json
+++ b/et.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Selle sõiduki paak on täis",
+	"petrolcan_cannot_afford": "Te ei saa endale bensiinikanistrit lubada",
+	"refuel_cannot_afford": "Te ei saa endale lubada oma sõiduki tankimist",
+	"vehicle_far": "Teie sõiduk on liiga kaugel",
+	"pump_fuel_with_can": "Enne pumbaga tankimist pange purk ära",
+	"fuel_help": "Tankimiseks vajutage nuppu ~INPUT_C2939D45~",
+	"petrolcan_help": "Kütusekannu ostmiseks või täitmiseks vajutage nuppu ~INPUT_C2939D45~",
+	"leave_vehicle": "Jätke auto käima tankimise alustamiseks",
+	"start_fueling": "Alusta tankimist",
+	"petrolcan_buy_or_refill": "Ostke või täitke kütusekanister",
+	"fuel_station_blip": "Tankla",
+	"not_enough_money": "Pole piisavalt raha! Puudub $%s",
+	"fuel_success": "Kütuses %s – $%s",
+	"petrolcan_refill": "Kütusekanistri täitmise eest maksti $%s",
+	"petrolcan_buy": "Kütusepurgi eest maksti $%s",
+	"petrolcan_cannot_carry": "Te ei saa seda kütusekannu kaasas kanda",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/fr.json
+++ b/fr.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Le réservoir de ce véhicule est plein",
+	"petrolcan_cannot_afford": "Vous ne pouvez pas acheter un jerrican",
+	"refuel_cannot_afford": "Vous n'avez pas les moyens de faire le plein de votre véhicule",
+	"vehicle_far": "Votre véhicule est trop loin",
+	"pump_fuel_with_can": "Rangez votre jerrican pour utiliser la pompe",
+	"fuel_help": "Appuyer sur ~INPUT_C2939D45~ pour faire le plein",
+	"petrolcan_help": "Appuyer sur ~INPUT_C2939D45~ pour acheter ou remplir un jerrican",
+	"leave_vehicle": "Sortez du véhicule pour pouvoir faire le plein",
+	"start_fueling": "Faire le plein",
+	"petrolcan_buy_or_refill": "Acheter ou remplir un jerrican",
+	"fuel_station_blip": "Station essence",
+	"not_enough_money": "Il vous manque $%s",
+	"fuel_success": "Rempli à %s - $%s",
+	"petrolcan_refill": "Vous avez payer $%s pour remplir votre jerrican",
+	"petrolcan_buy": "Vous avez payer $%s pour un jerrican",
+	"petrolcan_cannot_carry": "Vous ne pouvez pas porter ce jerrican",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/hr.json
+++ b/hr.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Rezervar je pun",
+	"petrolcan_cannot_afford": "Nemate dovoljno novca za kanister goriva",
+	"refuel_cannot_afford": "Nemate dovoljno novca da napunite vozilo",
+	"vehicle_far": "Vozilo je predaleko",
+	"pump_fuel_with_can": "Odmaknite kanister prije punjenja na pumpi",
+	"fuel_help": "Pritisni ~INPUT_C2939D45~ da natočiš gorivo",
+	"petrolcan_help": "Pritisni ~INPUT_C2939D45~ da kupite ili dopunite kanister",
+	"leave_vehicle": "Napustite vozilo prije punjenja",
+	"start_fueling": "Započni točenje",
+	"petrolcan_buy_or_refill": "Kupite ili napunite spremnik goriva",
+	"fuel_station_blip": "Benzinska pumpa",
+	"not_enough_money": "Nemate dovoljno novca! Fali Vam $%s",
+	"fuel_success": "Natočeno do %s - $%s",
+	"petrolcan_refill": "Platili ste $%s za punjenje vozila",
+	"petrolcan_buy": "Platili ste $%s za kanister",
+	"petrolcan_cannot_carry": "Ne možete nositi taj kanister",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/hu.json
+++ b/hu.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "A járműved tankja tele van",
+	"petrolcan_cannot_afford": "Nincs elég pénzed, hogy benzines kannát vegyél",
+	"refuel_cannot_afford": "Nincs elég pénzed a tankoláshoz",
+	"vehicle_far": "A jármű túl messze van",
+	"pump_fuel_with_can": "Tankolás előtt tedd el a kannát",
+	"fuel_help": "Nyomj ~INPUT_C2939D45~-t a tankoláshoz",
+	"petrolcan_help": "Nyomj ~INPUT_C2939D45~-t, hogy vegyél vagy újratöltds a kannát",
+	"leave_vehicle": "Szálj ki a járműből, hogy tankolhass",
+	"start_fueling": "Tankolás elkezdése",
+	"petrolcan_buy_or_refill": "Vegyél vagy töltds újra a kannát",
+	"fuel_station_blip": "Benzinkút",
+	"not_enough_money": "Nincs elég pénzed! Hiányzik $%s",
+	"fuel_success": "Tankoltál %s - $%s",
+	"petrolcan_refill": "Kifizettél $%s-t a kanna újratöltéséért",
+	"petrolcan_buy": "Kifizettél $%s-t a kannáért",
+	"petrolcan_cannot_carry": "Ezt a kannát nem szállíthatod",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/it.json
+++ b/it.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Il serbatoio di questo veicolo è pieno",
+	"petrolcan_cannot_afford": "Non puoi permetterti una tanica di benzina",
+	"refuel_cannot_afford": "Non puoi permetterti di fare rifornimento al tuo veicolo",
+	"vehicle_far": "Il yuo veicolo è troppo lontano",
+	"pump_fuel_with_can": "Metti via la tanica prima di fare rifornimento con la pompa",
+	"fuel_help": "Premi ~INPUT_C2939D45~ per fare rifornimento",
+	"petrolcan_help": "Premi ~INPUT_C2939D45~ per acquistare o riempire una tanica di carburante",
+	"leave_vehicle": "Uscire dal veicolo per poter iniziare a fare rifornimento",
+	"start_fueling": "Inizia rifornimento",
+	"petrolcan_buy_or_refill": "Compra o riempi una tanica di carburante",
+	"fuel_station_blip": "Stazione di rifornimento",
+	"not_enough_money": "Soldi insufficienti! Mancano $%s",
+	"fuel_success": "Rifornito a %s - $%s",
+	"petrolcan_refill": " Hai pagato $%s per aver riempito la tanica di carburante",
+	"petrolcan_buy": "Hai pagato $%s per una tanica di carburante",
+	"petrolcan_cannot_carry": "Non puoi trasportare questa tanica di carburante",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/nl.json
+++ b/nl.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "De tank van dit voertuig is vol",
+	"petrolcan_cannot_afford": "Je kan een jerrycan niet betalen",
+	"refuel_cannot_afford": "Je kan het niet betalen om je voertuig te tanken",
+	"vehicle_far": "Je voertuig is te ver weg",
+	"pump_fuel_with_can": "Doe je jerrycan weg voordat je kan tanken",
+	"fuel_help": "Klik op ~INPUT_C2939D45~ om te tanken",
+	"petrolcan_help": "Klik op ~INPUT_C2939D45~ om een jerrycan te kopen of bij te vullen",
+	"leave_vehicle": "Verlaat je voertuig om te tanken",
+	"start_fueling": "Start met tanken",
+	"petrolcan_buy_or_refill": "Koop of hervul een jerry can",
+	"fuel_station_blip": "Tankstation",
+	"not_enough_money": "Niet genoeg geld! Mist €%s",
+	"fuel_success": "Gevuld tot %s - €%s",
+	"petrolcan_refill": "Je hebt €%s betaald voor het vullen van je jerrycan",
+	"petrolcan_buy": "Je hebt €%s betaald voor een jerrycan",
+	"petrolcan_cannot_carry": "Je kan deze jerrycan niet tillen",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/pl.json
+++ b/pl.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "Zbiornik tego pojazdu jest pełny",
+	"petrolcan_cannot_afford": "Nie stać cię na kanister paliwa",
+	"refuel_cannot_afford": "Nie stać cię na zatankowanie tego pojazdu",
+	"vehicle_far": "Twój pojazd jest za daleko",
+	"pump_fuel_with_can": "Odłóż kanister paliwa przed rozpoczęciem tankowania",
+	"fuel_help": "Naciśnij ~INPUT_C2939D45~ aby zatankować",
+	"petrolcan_help": "Naciśnij ~INPUT_C2939D45~ aby kupić lub uzupełnić kanister",
+	"leave_vehicle": "Opuść pojazd, aby rozpocząć tankowanie",
+	"start_fueling": "Rozpocznij tankowanie",
+	"petrolcan_buy_or_refill": "Kup lub uzupełnij kanister",
+	"fuel_station_blip": "Stacja paliw",
+	"not_enough_money": "Nie masz wystarczającej ilości pieniędzy! Brakuje $%s",
+	"fuel_success": "Zatankowano do %s - $%s",
+	"petrolcan_refill": "Zapłacono $%s za uzupełnienie kanistra paliwa",
+	"petrolcan_buy": "Zapłacono $%s za kanister paliwa",
+	"petrolcan_cannot_carry": "Nie uniesiesz tego kanistra paliwa",
+	"petrolcan_missing": "You are not holding a fuel can"
+}

--- a/tc.json
+++ b/tc.json
@@ -1,0 +1,19 @@
+{
+	"tank_full": "該載具的油箱已滿",
+	"petrolcan_cannot_afford": "你沒有足夠的金錢來購買汽油罐",
+	"refuel_cannot_afford": "你沒有足夠的金錢來為你的載具加油",
+	"vehicle_far": "你的載具離得太遠了",
+	"pump_fuel_with_can": "在使用泵加油前先放下你的汽油罐",
+	"fuel_help": "按下 ~INPUT_C2939D45~ 來加油",
+	"petrolcan_help": "按下 ~INPUT_C2939D45~ 購買或補充汽油罐",
+	"leave_vehicle": "離開載具後才能開始加油",
+	"start_fueling": "開始加油",
+	"petrolcan_buy_or_refill": "購買或補充汽油罐",
+	"fuel_station_blip": "加油站",
+	"not_enough_money": "沒有足夠的金錢! 還缺少 $%s",
+	"fuel_success": "加油至 %s - $%s",
+	"petrolcan_refill": "支付了 $%s 來補充汽油罐",
+	"petrolcan_buy": "支付了 $%s 來購買汽油罐",
+	"petrolcan_cannot_carry": "你無法攜帶這個汽油罐",
+	"petrolcan_missing": "You are not holding a fuel can"
+}


### PR DESCRIPTION
When attempting to fuel entity using qtarget without a fuel can already equipped, error occurs. This replaces it with a message telling player they are not holding fuel can. 

Translations were not completed but the new lines were added to all locales.