### PR TITLE
some fix for target system

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -15,5 +15,6 @@
 	"petrolcan_refill": "Paid $%s for refilling your fuel can",
 	"petrolcan_buy": "Paid $%s for a fuel can",
 	"petrolcan_cannot_carry": "You cannot carry this fuel can",
-	"petrolcan_not_enough_fuel": "Your fuel can doesn't have enough fuel"
+	"petrolcan_not_enough_fuel": "Your fuel can doesn't have enough fuel",
+	"petrolcan_not_equipped": "You need to equip your fuel can"
 }


### PR DESCRIPTION
display petrol can option on pumps and start_fueling on vehicles **only if** Config.petrolCan.enabled
start_fueling on vehicles only if **player equipped** the fuel can